### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Page Specific Javascript Rails
+# Page Specific JavaScript Rails
 
 ## Overview
 
@@ -6,9 +6,9 @@ As we create our application, using a single file for all of our JS can cause a 
 
 ## Objectives
 
-1. Write and load page-specific Javascript in the Manifest
-3. Load page-specific Javascript through javascript_include_tag
-4. Creating a `content_for` page-specific JS and write Javascript in partials
+1. Write and load page-specific JavaScript in the Manifest
+2. Load page-specific JavaScript through the `javascript_include_tag`
+3. Creating a `content_for` page-specific JS and write JavaScript in partials
 
 
 ## Page-Specific JS in a manifest
@@ -22,7 +22,7 @@ By default, when you use the [Rails Generators](http://guides.rubyonrails.org/ge
 ```
 ## Controller Specific JS
 
-When the browser loads our JavaScript, it parses the entire file and runs it. With a big application this can be a lot of JS. Different pages might start to have functionality we don't want to share accross the application. An option to allow for a page-specific JS file to be loaded only with the pages we want is to use the name of the controller.
+When the browser loads our JavaScript, it parses the entire file and runs it. With a big application this can be a lot of JS. Different pages might start to have functionality we don't want to share across the application. An option to allow for a page-specific JS file to be loaded only with the pages we want is to use the name of the controller.
 
 ```erb
 <%= javascript_include_tag params[:controller] %>
@@ -31,7 +31,7 @@ When the browser loads our JavaScript, it parses the entire file and runs it. Wi
 Instead of adding blogs.js to the manifest file, we could instead load the file based off of the controller's name.  We can place this in the head or below the body of our layout and it will load the JS file that matches the name of the controller.
 
 A request made to `blogs#index` would result in params:
-`{controller: 'blogs', action: 'index'}` and the `javascript_include_tag` will now load the blogs.js file.  If we visit a page from a different controller, the `javascript_include_tag` will include the JS specific to that controller.
+`{controller: 'blogs', action: 'index'}` and the `javascript_include_tag` will now load the `blogs.js` file.  If we visit a page from a different controller, the `javascript_include_tag` will include the JS specific to that controller.
 
 The downside of this is we'd no longer be getting the benefits of asset concatenation or caching.  The browser will have to make a separate request for this file in addition to the request for the main concatenated `application.js` file.  The benefit of this strategy could be that we're less likely to invalidate the cache for our entire JS file if it is in pieces.
 
@@ -64,7 +64,7 @@ Anything placed in our script tag will run only on our show page.
 
 ## Class Based Targeting
 
-While both of those solutions work, some people find that they aren't the most elegant solutions to the problem.  One way you can continue to keep things simple with the asset pipeline is to continue to have it concatenate all of your javascript together, but wrap all your pages in a div with a specific class for that page.
+While both of those solutions work, some people find that they aren't the most elegant solutions to the problem.  One way you can continue to keep things simple with the asset pipeline is to continue to have it concatenate all of your JavaScript together, but wrap all your pages in a div with a specific class for that page.
 
 ```erb
 <%# app/views/layouts/application.html.erb %>
@@ -82,11 +82,11 @@ Assuming your `contact` page action was inside a controller named PagesControlle
 </body>
 ```
 
-Now you could write some javascript like this
+Now you could write some JavaScript like this
 ```javascript
 $(".pages.contact").click(function() {
   console.log("only runs on the contact page!")
 })
 ```
 
-<p data-visibility='hidden'>View <a href='https://learn.co/lessons/page-specific-javascript-rails' title='Page Specific Javascript Rails'>Page Specific Javascript Rails</a> on Learn.co and start learning to code for free.</p>
+<p data-visibility='hidden'>View <a href='https://learn.co/lessons/page-specific-javascript-rails' title='Page Specific JavaScript Rails'>Page Specific JavaScript Rails</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
- accross --> across
- standardize capitalization of JavaScript
